### PR TITLE
Read number of input channels directly

### DIFF
--- a/model/paradis.py
+++ b/model/paradis.py
@@ -186,12 +186,13 @@ class Paradis(nn.Module):
         # Get channel sizes
         self.num_dynamic_channels = len(datamodule.dataset.dyn_input_features)
         self.num_static_channels = len(cfg.features.input.constants)
+        self.num_input_channels = datamodule.dataset.num_in_features
 
         hidden_dim = cfg.model.hidden_multiplier * self.num_dynamic_channels
 
         # Input projection for combined dynamic and static features
         self.input_proj = CLP(
-            self.num_dynamic_channels + self.num_static_channels, hidden_dim, mesh_size
+            self.num_input_channels, hidden_dim, mesh_size
         )
 
         # Rescale the time step to a fraction of a synoptic time scale


### PR DESCRIPTION
This commit adjusts `Paradis.__init__` to read the number of input channels directly from
`datamodule.dataset.num_in_features`.  Previously, this was computed by adding the dynamic input features (in dataset) and the number of constant features (in config).

This appears to have missed the 'forcings' variables, causing a fresh install to immediately crash because it sees 97 channels when it expected 92.

The fix to use `num_in_features` avoids the problem of multiple sources of authority, and it should be robust to future changes in the dataset code.