### PR TITLE
Quality of life

### DIFF
--- a/config/paradis_settings.yaml
+++ b/config/paradis_settings.yaml
@@ -47,10 +47,12 @@ training:
   dataset:
     start_date: 2010-01-01         # Start date for the training dataset (YYYY-MM-DD)
     end_date: 2019-12-31           # End date for the training dataset (YYYY-MM-DD)
+    preload: false                 # If true, load the full dataset from disk into memory to speed training
 
   validation_dataset:
     start_date: 2008-01-01         # Start date for the validation dataset (YYYY-MM-DD)
     end_date: 2009-12-31           # End date for the validation dataset (YYYY-MM-DD)
+    preload: false                 # If true, load the full dataset from disk into memory to speed validation
     validation_every_n_steps: null # Run validation every N steps (null once per epoch)
     validation_batches: null       # If non-null, use N batches rather than all for validation (0 disables val)
 

--- a/config/paradis_settings.yaml
+++ b/config/paradis_settings.yaml
@@ -95,8 +95,8 @@ training:
     # 3. LambdaLR with initial warmup, steady learning rate and final cooldown
     wsd:
       enabled: false
-      warmup_pct: 0.01
-      decay_pct: 0.2
+      warmup: 100                    # ≥1 : number of warmup steps, else fraction
+      decay: 0.2                     # ≥1 : number of decay steps, else fraction
 
   variable_loss_weights:
     atmospheric:

--- a/config/paradis_settings.yaml
+++ b/config/paradis_settings.yaml
@@ -6,6 +6,10 @@ model:
   checkpoint_path: null            # Path to model checkpoint for loading pre-trained weights
   num_substeps: 2                  # Number of time substeps
 
+# Initialization settings (seeding)
+# init:
+  # seed: 42
+
 # Input dataset
 dataset:
   root_dir: /path/to/dataset/
@@ -34,7 +38,8 @@ forecast:
 
 # Training parameters
 training:
-  max_epochs: 500                  # Maximum number of epochs the training is allowed
+  max_epochs: -1                   # Maximum number of epochs the training is allowed (-1 to disable and use steps)
+  max_steps: 500                   # Maximum number of steps to use for training (-1 to disable and use epochs)
   gradient_clip_val: -1            # Gradient clipping value, set to -1 to disable
   print_losses: false              # Manually print losses to screen (removes progress bar)
   log_every_n_steps: 50            # Write to log every n steps
@@ -46,6 +51,8 @@ training:
   validation_dataset:
     start_date: 2008-01-01         # Start date for the validation dataset (YYYY-MM-DD)
     end_date: 2009-12-31           # End date for the validation dataset (YYYY-MM-DD)
+    validation_every_n_steps: null # Run validation every N steps (null once per epoch)
+    validation_batches: null       # If non-null, use N batches rather than all for validation (0 disables val)
 
   optimizer:
     lr: 1.0e-3                     # Learning rate (LR) for the optimizer

--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -41,6 +41,7 @@ class Era5DataModule(L.LightningDataModule):
                     start_date=train_start_date,
                     end_date=train_end_date,
                     forecast_steps=self.forecast_steps,
+                    preload=self.cfg.training.dataset.preload,
                     cfg=self.cfg,
                 )
 
@@ -57,6 +58,7 @@ class Era5DataModule(L.LightningDataModule):
                     start_date=val_start_date,
                     end_date=val_end_date,
                     forecast_steps=self.forecast_steps,
+                    preload=self.cfg.training.validation_dataset.preload,
                     cfg=self.cfg,
                 )
 
@@ -115,6 +117,7 @@ class Era5DataModule(L.LightningDataModule):
             shuffle=True,
             pin_memory=True,
             drop_last=self.drop_last,
+            persistent_workers=True,
         )
 
     def val_dataloader(self):
@@ -122,11 +125,12 @@ class Era5DataModule(L.LightningDataModule):
         return DataLoader(
             self.val_dataset,
             batch_size=self.batch_size,
-            num_workers=1,  # self.num_workers,
+            num_workers=self.num_workers,
             # Shuffle if we're using less than all validation data
             shuffle=self.cfg.training.validation_dataset.validation_batches is not None,
             pin_memory=True,
             drop_last=self.drop_last,
+            persistent_workers=True,
         )
 
     def predict_dataloader(self):

--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -122,8 +122,9 @@ class Era5DataModule(L.LightningDataModule):
         return DataLoader(
             self.val_dataset,
             batch_size=self.batch_size,
-            num_workers=self.num_workers,
-            shuffle=False,
+            num_workers=1,  # self.num_workers,
+            # Shuffle if we're using less than all validation data
+            shuffle=self.cfg.training.validation_dataset.validation_batches is not None,
             pin_memory=True,
             drop_last=self.drop_last,
         )

--- a/train.py
+++ b/train.py
@@ -49,6 +49,7 @@ def main(cfg: DictConfig):
         logger=True,
         val_check_interval=cfg.training.validation_dataset.validation_every_n_steps,
         limit_val_batches=cfg.training.validation_dataset.validation_batches,
+        enable_checkpointing=cfg.training.checkpointing.enabled,
     )
 
     # Keep track of configuration parameters in logging directory

--- a/train.py
+++ b/train.py
@@ -38,6 +38,7 @@ def main(cfg: DictConfig):
         devices=cfg.compute.num_devices,
         strategy="auto" if cfg.compute.num_devices == 1 else "fsdp",
         max_epochs=cfg.training.max_epochs,
+        max_steps=cfg.training.max_steps,
         gradient_clip_val=cfg.training.gradient_clip_val,
         gradient_clip_algorithm="norm",
         log_every_n_steps=cfg.training.log_every_n_steps,
@@ -46,6 +47,8 @@ def main(cfg: DictConfig):
         enable_progress_bar=not cfg.training.print_losses,
         enable_model_summary=True,
         logger=True,
+        val_check_interval=cfg.training.validation_dataset.validation_every_n_steps,
+        limit_val_batches=cfg.training.validation_dataset.validation_batches,
     )
 
     # Keep track of configuration parameters in logging directory

--- a/trainer.py
+++ b/trainer.py
@@ -225,10 +225,24 @@ class LitParadis(L.LightningModule):
         elif cfg.scheduler.wsd.enabled:
             total_steps = self.trainer.estimated_stepping_batches
 
-            assert (cfg.scheduler.wsd.warmup_pct + cfg.scheduler.wsd.decay_pct) <= 1.0
+            # Set warmup and decay periods
+            if cfg.scheduler.wsd.warmup >= 1:
+                # Value >= 1, so it's a number of steps
+                warmup_steps = cfg.scheduler.wsd.warmup
+            else:
+                warmup_steps = cfg.scheduler.wsd.warmup * total_steps
 
-            warmup_steps = int(cfg.scheduler.wsd.warmup_pct * total_steps)
-            decay_steps = int(cfg.scheduler.wsd.decay_pct * total_steps)
+            if cfg.scheduler.wsd.decay >= 1:
+                # Value >= 1, so it's a number of steps
+                decay_steps = cfg.scheduler.wsd.decay
+            else:
+                decay_steps = cfg.scheduler.wsd.decay * total_steps
+
+            # Sanity checks
+            assert warmup_steps >= 0
+            assert decay_steps >= 0
+            assert warmup_steps + decay_steps <= total_steps
+
             steady_steps = total_steps - (warmup_steps + decay_steps)
 
             def lr_lambda(step):

--- a/trainer.py
+++ b/trainer.py
@@ -291,7 +291,7 @@ class LitParadis(L.LightningModule):
             "train_loss",
             train_loss / self.forecast_steps,
             on_step=True,
-            on_epoch=True,
+            on_epoch=False,
             prog_bar=True,
             sync_dist=True,
         )
@@ -354,7 +354,7 @@ class LitParadis(L.LightningModule):
         self.log(
             "val_loss",
             val_loss / self.forecast_steps,
-            on_step=True,
+            on_step=False,
             on_epoch=True,
             prog_bar=True,
             sync_dist=True,
@@ -364,8 +364,8 @@ class LitParadis(L.LightningModule):
         self.log(
             "GZ500-RMSE",
             gz500_loss / self.forecast_steps,
-            on_step=True,
-            on_epoch=False,
+            on_step=False,
+            on_epoch=True,
             prog_bar=True,
             sync_dist=True,
         )

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -2,11 +2,30 @@ import lightning as L
 
 from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 from lightning.pytorch.callbacks import ModelCheckpoint
+from lightning.pytorch.callbacks import TQDMProgressBar
 
+class ModProgressBar(TQDMProgressBar):
+    '''Slightly modified version of ProgressBar to remove v_num entry, see
+    https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ProgressBar.html'''
+
+    def __init__(self):
+        super().__init__()
+        self.enable = True
+
+    def disable(self):
+        self.enable = False
+
+    def get_metrics(self, trainer, model):
+        # don't show the version number
+        items = super().get_metrics(trainer, model)
+        items.pop("v_num", None)
+        return items
 
 def enable_callbacks(cfg):
     # Define callbacks
     callbacks = []
+    callbacks.append(ModProgressBar())
+
     if cfg.training.early_stopping.enabled:
         # Stop epochs when validation loss is not decreasing during a coupe of epochs
         callbacks.append(

--- a/utils/system.py
+++ b/utils/system.py
@@ -7,7 +7,10 @@ from omegaconf import OmegaConf
 
 def setup_system(cfg):
     # Set random seeds for reproducibility
-    seed = 42  # This model will answer the ultimate question about life, the universe, and everything
+    if "init" in cfg and "seed" in cfg["init"]:
+        seed = cfg["init"]["seed"]
+    else:
+        seed = 42  # This model will answer the ultimate question about life, the universe, and everything
     L.seed_everything(seed, workers=True)
 
     # Choose double (32-true) or mixed (16-mixed) precision via AMP


### PR DESCRIPTION
This set of commits adds a few "quality of life" features that might be useful for more rapid testing cycles:

* Specification of the random seed in the config file
* Option to run a fixed number of training steps rather than epochs
* Option to limit the number of validation batches (0 to disable validation)
* Option to run validation every N steps rather than once per epoch
* Options to preload the training/validation datasets for much faster training at low resolution
* Tweak to wsd schedule to allow specification of a fixed number of warmup or decay steps rather than a fraction of total steps