### PR TITLE
Consolidate nn.module use into simple and GMBlock

### DIFF
--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -5,10 +5,11 @@ import lightning as L
 from torch.utils.data import DataLoader
 
 from data.era5_dataset import ERA5Dataset
+from omegaconf import DictConfig
 
 
 class Era5DataModule(L.LightningDataModule):
-    def __init__(self, cfg: dict) -> None:
+    def __init__(self, cfg: DictConfig) -> None:
         super().__init__()
 
         # Extract configuration parameters for data

--- a/data/era5_dataset.py
+++ b/data/era5_dataset.py
@@ -30,7 +30,7 @@ class ERA5Dataset(torch.utils.data.Dataset):
         forecast_steps: int = 1,
         dtype=torch.float32,
         preload=False,  # Whether to preload the dataset
-        cfg: DictConfig = {},
+        cfg: DictConfig = DictConfig({}),
     ) -> None:
 
         self.cfg = cfg
@@ -251,7 +251,7 @@ class ERA5Dataset(torch.utils.data.Dataset):
         )
 
         # Load arrays into CPU memory
-        input_data, true_data = dask.compute(input_data, true_data)
+        input_data, true_data = dask.compute(input_data, true_data) # type: ignore -- dask.compute is really dask.base.compute
 
         # # Add checks for invalid values
         if numpy.isnan(input_data.data).any() or numpy.isnan(true_data.data).any():
@@ -422,7 +422,7 @@ class ERA5Dataset(torch.utils.data.Dataset):
         forcings = []
         for var in self.forcing_inputs:
             if var == "toa_incident_solar_radiation":
-                toa_rad = toa_radiation(input_data["time"].values, self.lat, self.lon)
+                toa_rad = toa_radiation(input_data["time"].values, self.lat.cpu().numpy(), self.lon.cpu().numpy())
 
                 toa_rad = torch.tensor(
                     (toa_rad - self.toa_rad_mean) / self.toa_rad_std,

--- a/model/clp_block.py
+++ b/model/clp_block.py
@@ -3,6 +3,13 @@ from torch import nn
 
 from model.padding import GeoCyclicPadding
 
+from typing import Callable
+
+# For type hinting, define a type for Pytorch activation functions.  These
+# are classes that take an optional boolean (inplace, ignored) and return a
+# function/object that takes tensors and returns tensors
+ActivationType = Callable[[], Callable[[torch.Tensor], torch.Tensor]]
+
 
 class CLPBlock(nn.Module):
     """Convolutional Layer Processor block."""
@@ -13,7 +20,7 @@ class CLPBlock(nn.Module):
         output_dim: int,
         mesh_size: tuple,
         kernel_size: int = 3,
-        activation: nn.Module = nn.SiLU,
+        activation: ActivationType = nn.SiLU,
         double_conv: bool = False,
         pointwise_conv: bool = False,
     ):
@@ -61,7 +68,7 @@ def CLP(
     dim_out: int,
     mesh_size: tuple,
     kernel_size: int = 3,
-    activation: nn.Module = nn.SiLU,
+    activation: ActivationType = nn.SiLU,
     pointwise_conv: bool = False,
 ):
     """Create a double-convolution CLP block."""

--- a/model/clp_block.py
+++ b/model/clp_block.py
@@ -3,12 +3,11 @@ from torch import nn
 
 from model.padding import GeoCyclicPadding
 
-from typing import Callable
+from typing import Type
 
-# For type hinting, define a type for Pytorch activation functions.  These
-# are classes that take an optional boolean (inplace, ignored) and return a
-# function/object that takes tensors and returns tensors
-ActivationType = Callable[[], Callable[[torch.Tensor], torch.Tensor]]
+# Type for the Activation functions.  These subclass nn.Module, and the class itself
+# is passed to CLPBlock
+ActivationType = Type[nn.Module]
 
 
 class CLPBlock(nn.Module):

--- a/model/gmblock.py
+++ b/model/gmblock.py
@@ -1,0 +1,144 @@
+import torch
+from torch import nn
+from collections import OrderedDict  # For nn.Sequential
+from collections.abc import Sequence
+
+from typing import Union, Type, Tuple
+
+ActivationType = Type[nn.Module]
+
+# Build directory of simple blocks by inspecting the simple_blocks submodule, allowing
+# configuration by string
+directory = {}
+import inspect
+import model.simple_blocks
+
+for k, v in inspect.getmembers(model.simple_blocks):
+    if inspect.isclass(v) and issubclass(v, nn.Module):
+        directory[k] = v
+
+
+class GMBlock(nn.Sequential):
+    """GMBlock: Generic Multilayer Block: compose several simple blocks with activation
+    functions, giving a composite multilayer, nonlinear block.
+
+    This class generalizes the previous convolutional layer processor block.  The CLPBlock
+    contained many bespoke configuration options that in effect defined the implied number
+    of layers, but it's simpler to just specify the layers directly.
+    """
+
+    def __init__(
+        self,
+        layers: Sequence[
+            Union[str, Type[nn.Module]]
+        ],  # sequence of modules for layers, allowing string lookup
+        input_dim: int,  # Size of the input dimension
+        output_dim: int,  # Size of the output dimension
+        mesh_size: Tuple[int, int],  # 2D mesh size, NLat by NLon
+        kernel_size: int = 3,  # Size of kernel for all 2D convolutional layers
+        hidden_dim: Union[
+            Sequence, int
+        ] = 0,  # Size of hidden dimension; if <=0 use max(input,output); if list use per-layer
+        activation_fn: ActivationType = nn.SiLU,  # Activation function to use
+        bias_channels: int = 0,  # Number of learned bias channels
+        activation: Union[
+            Sequence, bool
+        ] = False,  # Sequence: apply activation function per layer?  Bool: final layer only?
+        pre_normalize: bool = False,  # Whether to apply a prenorm (ChannelNorm) to the input before other layers
+    ):
+        """Perform initialization and construct layer sequence"""
+
+        num_layers = len(layers)
+        if num_layers == 0:
+            raise ValueError("GMBlock: must specify at least one layer")
+
+        if isinstance(activation, Sequence):  # Given a list of activations
+            assert (
+                len(activation) == num_layers
+            )  # Assert activatation list is the correct size
+        else:
+            # Otherwise, build the activation list; activate all layers except optionally the
+            # final one.  Note that two linear layers concatenated without an activation just
+            # form a more complicated linear layer.
+            activation = (True,) * (num_layers - 1) + (activation,)
+
+        if isinstance(hidden_dim, Sequence):  # Given an input list
+            assert len(hidden_dim) == num_layers - 1  # Assert it must be the right size
+        else:
+            if hidden_dim <= 0:
+                # If the hidden dimension size is unspecified, use the
+                # larger of input and output dimensions
+                hidden_dim = max(input_dim, output_dim)
+            # Replicate hidden_dim to sequence, re-using the same hidden dimension
+            # for each internal layer
+            hidden_dim = (hidden_dim,) * (num_layers - 1)
+
+        # Initialize first layer and bias layer specially
+        layer_in_size = input_dim
+
+        blocks = []
+        if pre_normalize:
+            # Add a ChannelNorm layer before everything else
+            blocks.append(
+                (
+                    "0-ChannelNorm",
+                    model.simple_blocks.ChannelNorm(
+                        input_dim=input_dim, output_dim=input_dim
+                    ),
+                )
+            )
+
+        for idx, l in enumerate(layers):
+            # Construct the list of blocks
+            if isinstance(
+                l, str
+            ):  # Layer specified by string, look up in SimpleBlocks directory
+                ltype = directory[l]
+            else:  # Otherwise, assume it's a type
+                assert issubclass(l, nn.Module)
+                ltype = l
+
+            # Get the layer output size
+            if idx == num_layers - 1:
+                # Output layer
+                layer_out_size = output_dim
+            else:
+                # Use hidden dimensions ize
+                layer_out_size = hidden_dim[idx]
+
+            ltypename = ltype.__name__
+            layer_name = f"{idx}-{ltypename}"
+            layer_obj = ltype(
+                input_dim=layer_in_size,
+                output_dim=layer_out_size,
+                mesh_size=mesh_size,
+                kernel_size=kernel_size,
+            )
+
+            blocks.append((layer_name, layer_obj))
+
+            if idx == 0 and bias_channels > 0:  # Add optional bias after first layer
+                # The GlobalBias block is constructed a bit specially, where input_dim refers to the fundamental
+                # number of bias channels rather than the size of (x) given to .forward(x).  When invoked, GlobalBias
+                # just adds the bias factor to (x), so #channels(x) == output_dim.  The construction used here effectively
+                # acts like appending #bias channels to the input, then expanding the first (input) layer to input_dim+bias_channels.
+
+                blocks.append(
+                    (
+                        f"0-GlobalBias",
+                        model.simple_blocks.GlobalBias(
+                            input_dim=bias_channels,
+                            output_dim=layer_out_size,
+                            mesh_size=mesh_size,
+                        ),
+                    )
+                )
+
+            # Add activation if necessary
+            if activation[idx]:
+                blocks.append((f"{idx}-{activation_fn.__name__}", activation_fn()))
+
+            # input size of next layer is the output of this layer
+            layer_in_size = layer_out_size
+
+        super().__init__(OrderedDict(blocks))

--- a/model/paradis.py
+++ b/model/paradis.py
@@ -7,6 +7,8 @@ from model.clp_block import CLP
 from model.clp_variational import VariationalCLP
 from model.padding import GeoCyclicPadding
 
+from typing import Tuple, Union
+
 
 class NeuralSemiLagrangian(nn.Module):
     """Implements the semi-Lagrangian advection."""
@@ -66,9 +68,10 @@ class NeuralSemiLagrangian(nn.Module):
         lat_grid: torch.Tensor,
         lon_grid: torch.Tensor,
         dt: float,
-    ) -> torch.Tensor:
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor,torch.Tensor]]:
         """Compute advection using rotated coordinate system."""
         batch_size = hidden_features.shape[0]
+        kl_loss = torch.tensor(0.0)
 
         # Get learned velocities for each channel
         if self.variational:
@@ -178,7 +181,7 @@ class Paradis(nn.Module):
 
         # Extract dimensions from config
         output_dim = datamodule.num_out_features
-        mesh_size = [datamodule.lat_size, datamodule.lon_size]
+        mesh_size = (datamodule.lat_size, datamodule.lon_size)
         num_levels = len(cfg.features.pressure_levels)
         self.num_common_features = datamodule.num_common_features
         self.variational = cfg.ensemble.enable
@@ -193,9 +196,7 @@ class Paradis(nn.Module):
         hidden_dim = cfg.model.hidden_multiplier * self.num_dynamic_channels
 
         # Input projection for combined dynamic and static features
-        self.input_proj = CLP(
-            self.num_input_channels, hidden_dim, mesh_size
-        )
+        self.input_proj = CLP(self.num_input_channels, hidden_dim, mesh_size)
 
         # Rescale the time step to a fraction of a synoptic time scale
         self.num_substeps = cfg.model.num_substeps

--- a/model/simple_blocks.py
+++ b/model/simple_blocks.py
@@ -1,0 +1,302 @@
+import torch
+from torch import nn
+
+from model.padding import GeoCyclicPadding
+
+from typing import Any  # For optional/unused parameters
+from typing import Tuple  # For mesh_size when used
+
+"""
+    simple_blocks: Wrapper file to consolidate simple NN layers, defined as those that do
+    not have activation functions.  This includes convolution, normalization, and bias layers.
+
+    These modules are specialized to expect Tensors of shape (batch,channels,lat,lon).
+
+    For consistency, all of these modules are defined to take the following parameters:
+        * input_dim -- number of input channels
+        * output_dim -- number of output channels
+        * kernel_size -- width of the convolution kernel
+        * bias -- whether to add a bias term
+        * mesh_size -- (lat, lon) tuple of 2D mesh size
+
+    Not all parameters are relevant to each module, and they will be either ignored if
+    inapplicable or tested for consistency if the module imposes stricter requirements.
+    For example, the convolution layers don't care about grid size and will ignore the
+    mesh_size parameter, but FlatConv (2D-only convolution) cannot change the number
+    of channels and will check that input_dim == output_dim.
+"""
+
+
+class FullConv(nn.Conv2d):
+    """Wrapper function for a full 2D convolution, acting across all channels.  This
+    creates C_out×C_in×(kernel)×(kernel) weight parameters and C bias parameters.  Includes
+    GeoCyclic padding.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        *,
+        kernel_size: int,  # Required
+        bias: bool = True,  # Optional
+        mesh_size: Any = None,  # Not used
+    ):
+
+        self._kernel_size = kernel_size
+
+        super().__init__(input_dim, output_dim, kernel_size=kernel_size, bias=bias)
+
+        if self._kernel_size > 1:
+            self._padding = GeoCyclicPadding(kernel_size // 2)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self._kernel_size > 1:
+            input = self._padding(input)
+        return super().forward(input)
+
+
+class FlatConv(nn.Conv2d):
+    """Wrapper class for a limited 2D convolution, acting on each channel independently.
+    This creates C×1x(kernel)x(kernel) paremeters and C bias parameters.  Includes
+    GeoCyclic padding and cannot change the number of channels.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,  # Must equal input dimension
+        *,
+        kernel_size: int,  # Required
+        bias: bool = True,  # Optional
+        mesh_size: Any = None,  # Not used
+    ):
+        assert input_dim == output_dim
+        dim = input_dim
+
+        self._kernel_size = kernel_size
+
+        super().__init__(dim, dim, kernel_size=kernel_size, groups=dim, bias=bias)
+
+        if self._kernel_size > 1:
+            self._padding = GeoCyclicPadding(kernel_size // 2)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self._kernel_size > 1:
+            input = self._padding(input)
+        return super().forward(input)
+
+
+class CLinear(nn.Conv2d):
+    """Linear layer that acts across the channel dimension, having C_out × C_in weight
+    parameters and C_out bias parameters."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        *,
+        kernel_size: int = 1,  # Not used (linear always has a kernel size of 1)
+        bias: bool = True,  # Optional
+        mesh_size: Any = None,  # Not used
+    ):
+        super().__init__(input_dim, output_dim, kernel_size=1, bias=bias)
+
+
+class SepConv(nn.Module):
+    """Wrapper class for a "separated" convolution, which acts first in 2D (across channels)
+    and then applies a CLinear operator.  Has C_in×1×K×K + C_out×C_in weight parameters and
+    C_out bias parameters (no bias applied during the 2D convolution)
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        *,
+        kernel_size: int,  # Required
+        bias: bool = True,  # Optional
+        mesh_size: Any = None,  # Not used
+    ):
+        super().__init__()
+
+        self.kernel_size = kernel_size
+
+        if kernel_size > 1:
+            self.padding = GeoCyclicPadding(kernel_size // 2)
+
+        self.conv = nn.Conv2d(
+            input_dim, input_dim, kernel_size, groups=input_dim, bias=False
+        )
+        self.linear = CLinear(input_dim, output_dim, bias=bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.kernel_size > 1:
+            x = self.padding(x)
+        x = self.conv(x)
+        x = self.linear(x)
+        return x
+
+
+## GlobalNorm -- full 3D normalization
+class GlobalNorm(nn.LayerNorm):
+    """Performs a "global normalization" using the pytorch LayerNorm infrasturcture.
+
+    LayerNorm is defined to act over the last several dimensions of a tensor, and in our
+    ordering that means (channel,lat,lon).  A three-dimensional layer norm thus normalizes
+    the model *globally*.  As a result, this module creates 2*C*lat*lon parameters, for the
+    scale and bias of each point separately.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        *,
+        bias: bool = True,  # passed to LayerNorm
+        kernel_size: int = 1,  # Not used
+        mesh_size: Tuple[int, int],  # required
+    ):
+        assert input_dim == output_dim
+        super().__init__(list((input_dim,) + mesh_size), bias=bias)
+
+
+## ChannelNorm -- layer normalization across channels only
+
+
+class ChannelNorm(nn.Module):
+    """Performs a "channel normalization," equivalent to LayerNorm in attention and
+    graph neural networks.
+
+    Unlike GlobalNorm above, this module is defined to normalize along the channel
+    dimension (dim -3 or +1) only.  This is more consistent to standard practice in
+    attention-based models, whereby each token's latent spae is normalized separately;
+    it is also used throughout Graphcast in a similar way.  Unlike GlobalNorm, this
+    module only creates 2*C parameters.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        *,
+        kernel_size: int = 1,  # Not used
+        bias: bool = True,  # Optional
+        mesh_size: Any = None,  # Not used
+    ):
+        assert input_dim == output_dim
+        super().__init__()
+
+        self.eps = 1e-5  # Fudge factor for standard deviation, copied from LayerNorm
+        self.dim = input_dim
+
+        self.weight = nn.Parameter(torch.ones(input_dim), requires_grad=True)
+        if bias:
+            self.bias = nn.Parameter(torch.zeros(input_dim), requires_grad=True)
+        else:
+            self.bias = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Compute current channel statistics
+        cvar, cmean = torch.var_mean(x, dim=-3, keepdim=False)
+
+        # Compute the inverse standard deviation for normalization
+        inv_std = (self.eps + cvar) ** -0.5
+
+        # Subtract mean from x
+        shifted_x = x - cmean[..., None, :, :]  # Broadcast mean to correct shape
+
+        # Apply inverse standard deviation and affine weight.
+        # Using einsum (especially with opt_einsum) gives the engine a chance
+        # to more efficiently fuse and reorder operations
+        x = torch.einsum("...cij,...ij,c->...cij", shifted_x, inv_std, self.weight)
+
+        # If present, add bias (broadcast to the correct shape)
+        if self.bias is not None:
+            x = x + self.bias[..., :, None, None]
+
+        return x
+
+
+## NormedConv -- convolution with global norm (used by CLP)
+
+
+class NormedConv(nn.Module):
+    """
+    NormedConv builds a post-normalized convolution operator that applise a FullConv followed
+    by a GlobalNorm, in terms of the simple layers defined in this file.  This is a complicated
+    case that should ordinarily be constructed separately, but the current formulation of CLP
+    uses this as a basic quasi-linear building block.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        *,
+        bias: bool = True,  # passed to GlobalNorm
+        kernel_size: int,  # required
+        mesh_size: Tuple[int, int],  # required
+    ):
+        super().__init__()
+
+        self.conv = FullConv(input_dim, output_dim, kernel_size=kernel_size, bias=True)
+        self.norm = GlobalNorm(output_dim, output_dim, mesh_size=mesh_size, bias=bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv(x)
+        x = self.norm(x)
+        return x
+
+
+## GlobalBias -- learned bias operator
+class GlobalBias(nn.Module):
+    """
+    GlobalBias -- construct a learned bias operator, consisting of a few channels that
+    independently vary at each grid point.  This operator allows the model designer to
+    add learned geophyiscal features in a controlled way, see AIFS's small-number-of-
+    parameters per token for example.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        *,
+        bias: bool = True,  # Not used (would be redundant)
+        kernel_size: int = 0,  # Not used
+        mesh_size: Tuple[int, int],  # required
+    ):
+        super().__init__()
+
+        # The bias is a Cin  * lat * lon set of parameters.  The bias parameters start at zero
+        # (no bias) and are learned over the optimization
+        self.bias = nn.Parameter(
+            torch.zeros(((input_dim,) + mesh_size)), requires_grad=True
+        )
+
+        # If the input (number of bias channels) and output (size of latent space) dimensions
+        # aren't the same, we need a projection matrix to move from one to the other.  This
+        # projection matrix should be randomly initialized; if it were also zero then gradients
+        # couldn't flow back to the bias term
+        if input_dim != output_dim:
+            # Note that we'll use the projection weights directly in forward(), but wrapping
+            # it in a Linear is handy for initialization.  No projection bias term is necessary
+            # or desired.
+            self.projection = nn.Linear(input_dim, output_dim, bias=False)
+        else:
+            self.projection = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Construct the expanded bias term
+        if self.projection is None:
+            y = self.bias  # No projection necessary
+        else:
+            # Apply the projection operator to the bias along the channel dimension
+            # note that no batch dimension exists yet, that's only on x and we can
+            # broadcast that later, saving on memory bandwidth
+            y = torch.einsum("iab,ji->jab", self.bias, self.projection.weight)
+
+        # Apply the expanded bias to x
+        x = x + y[..., :, :, :]
+        return x

--- a/train.py
+++ b/train.py
@@ -44,7 +44,7 @@ def main(cfg: DictConfig):
         log_every_n_steps=cfg.training.log_every_n_steps,
         callbacks=callbacks,
         precision="16-mixed" if cfg.compute.use_amp else "32-true",
-        enable_progress_bar=not cfg.training.print_losses,
+        enable_progress_bar=cfg.training.progress_bar and not cfg.training.print_losses,
         enable_model_summary=True,
         logger=True,
         val_check_interval=cfg.training.validation_dataset.validation_every_n_steps,

--- a/train.py
+++ b/train.py
@@ -53,7 +53,7 @@ def main(cfg: DictConfig):
     )
 
     # Keep track of configuration parameters in logging directory
-    save_train_config(trainer.logger.log_dir, cfg)
+    save_train_config(trainer.logger.log_dir, cfg)  # type: ignore
 
     # Train model
     trainer.fit(litmodel, datamodule=datamodule, ckpt_path=cfg.model.checkpoint_path)

--- a/train.py
+++ b/train.py
@@ -56,7 +56,7 @@ def main(cfg: DictConfig):
     save_train_config(trainer.logger.log_dir, cfg)
 
     # Train model
-    trainer.fit(litmodel, datamodule=datamodule)
+    trainer.fit(litmodel, datamodule=datamodule, ckpt_path=cfg.model.checkpoint_path)
 
 
 if __name__ == "__main__":

--- a/trainer.py
+++ b/trainer.py
@@ -418,3 +418,16 @@ class LitParadis(L.LightningModule):
     def on_train_end(self):
         """Called when training ends."""
         logging.info(f"Training completed after {self.current_epoch + 1} epochs")
+
+    def on_before_optimizer_step(self, optimizer):
+        import torch
+
+        gradmag = sum(torch.sum(v.grad**2) for (k, v) in self.named_parameters()) ** 0.5
+
+        self.log(
+            "gradmag",
+            gradmag,
+            on_step=True,
+        )
+
+        return super().on_before_optimizer_step(optimizer)

--- a/trainer.py
+++ b/trainer.py
@@ -255,9 +255,18 @@ class LitParadis(L.LightningModule):
                 "optimizer": optimizer,
                 "lr_scheduler": {"scheduler": scheduler, "interval": "step"},
             }
-
         else:
-            raise ValueError(f"Unknown scheduler type: {cfg.scheduler.type}")
+            # No known scheduler was active
+            active_schedulers = [
+                k for (k, v) in cfg.scheduler.items() if "enabled" in v and v["enabled"]
+            ]
+            if len(active_schedulers) == 0:
+                # Should not happen if enabled_schedulers check above is still present
+                raise ValueError(f"No scheduler activated")
+            else:
+                raise ValueError(
+                    f'Unknown schedule activated: {", ".join(active_schedulers)}'
+                )
 
     def on_train_epoch_start(self):
         """Record the start time of the epoch."""

--- a/trainer.py
+++ b/trainer.py
@@ -431,3 +431,25 @@ class LitParadis(L.LightningModule):
         )
 
         return super().on_before_optimizer_step(optimizer)
+
+    def on_train_batch_start(self, batch, batch_idx):
+        import datetime
+
+        # Record current time for time-per-step calculation
+        self.tic = datetime.datetime.now()
+
+        return super().on_train_batch_start(batch, batch_idx)
+
+    def optimizer_step(self, epoch, batch_idx, optimizer, optimizer_closure=None):
+        import datetime
+
+        super().optimizer_step(epoch, batch_idx, optimizer, optimizer_closure)
+        # optimizer.step(closure=optimizer_closure)
+
+        # After the optimzier step, comptue and log how long the step took
+        toc = datetime.datetime.now()
+        self.log(
+            "dt",
+            (toc - self.tic).total_seconds(),
+            on_step=True,
+        )

--- a/trainer.py
+++ b/trainer.py
@@ -104,14 +104,6 @@ class LitParadis(L.LightningModule):
                 backend="inductor",
             )
 
-        # Load the model weights if a checkpoint path is provided
-        if cfg.model.checkpoint_path:
-            # Load into CPU, then Lightning will transfer to GPU
-            checkpoint = torch.load(
-                cfg.model.checkpoint_path, weights_only=True, map_location="cpu"
-            )
-            self.load_state_dict(checkpoint["state_dict"])
-
         self.epoch_start_time = None
 
         # Store the index of the GZ100 quantity to
@@ -184,8 +176,8 @@ class LitParadis(L.LightningModule):
         # Ensure only one is enabled
         if enabled_schedulers != 1:
             raise ValueError(
-                f'Invalid config: Exactly one scheduler must ' +
-                f'be enabled, but found {enabled_schedulers} enabled.'
+                f"Invalid config: Exactly one scheduler must "
+                + f"be enabled, but found {enabled_schedulers} enabled."
             )
 
         if cfg.scheduler.one_cycle.enabled:

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -4,12 +4,14 @@ from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.callbacks import TQDMProgressBar
 
-class ModProgressBar(TQDMProgressBar):
-    '''Slightly modified version of ProgressBar to remove v_num entry, see
-    https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ProgressBar.html'''
 
-    def __init__(self):
-        super().__init__()
+class ModProgressBar(TQDMProgressBar):
+    """Slightly modified version of ProgressBar to remove v_num entry, see
+    https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ProgressBar.html
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.enable = True
 
     def disable(self):
@@ -21,10 +23,64 @@ class ModProgressBar(TQDMProgressBar):
         items.pop("v_num", None)
         return items
 
+    def on_train_epoch_start(self, trainer, *_):
+        # Default: replaces the training progress bar with one
+        # for the current epoch.  Modified: *don't* replace
+        # the progress bar, and ensure it's set for a total
+        # number of training steps
+        total_batches = trainer.estimated_stepping_batches
+        # Calculate max epochs
+        if trainer.max_epochs > 0:
+            max_epochs = trainer.max_epochs
+        else:
+            max_epochs = 1 + (total_batches - 1) // trainer.num_training_batches
+        if total_batches != self.train_progress_bar.total:
+            # Store the current progress bar info
+            n = self.train_progress_bar.n
+            last_print_n = self.train_progress_bar.last_print_n
+            last_print_t = self.train_progress_bar.last_print_t
+            start_t = self.train_progress_bar.start_t
+            # Reset the progress bar total
+            self.train_progress_bar.reset(total_batches)
+            # Restore current n
+            self.train_progress_bar.update(n)
+            # Restore printing settings so progress isn't screwed up
+            self.train_progress_bar.last_print_n = last_print_n
+            self.train_progress_bar.last_print_t = last_print_t
+            self.train_progress_bar.start_t = start_t
+        self.train_progress_bar.set_description(
+            f"Epoch {trainer.current_epoch+1}/{max_epochs}"
+        )
+        self.train_progress_bar.refresh()
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        # Update the progress bar based on the total number of batches
+        n = batch_idx + trainer.current_epoch * trainer.num_training_batches + 1
+        if self._should_update(n, self.train_progress_bar.total):
+            self.train_progress_bar.set_postfix(self.get_metrics(trainer, pl_module))
+            if not (self.train_progress_bar.disable):
+                self.train_progress_bar.n = n
+                self.train_progress_bar.refresh()
+
+    def on_train_epoch_end(self, trainer, pl_module):
+        # Override default behaviour to not close the progress
+        # bar at epoch-end, regardless of 'leave' parameter (the bar isn't done)
+        if not self.train_progress_bar.disable:
+            self.train_progress_bar.set_postfix(self.get_metrics(trainer, pl_module))
+
+    def on_train_end(self, *_):
+        # Explicitly close the *container* of the progress bar, working around the
+        # inexplicable littering of progress bars in Jupyter notebooks
+        if not self._leave and 'container' in self.train_progress_bar.__dict__:
+            self.train_progress_bar.container.close()
+        return super().on_train_end(*_)
+
+
 def enable_callbacks(cfg):
     # Define callbacks
     callbacks = []
-    callbacks.append(ModProgressBar())
+    if cfg.training.progress_bar and not cfg.training.print_losses:
+        callbacks.append(ModProgressBar(leave=False))
 
     if cfg.training.early_stopping.enabled:
         # Stop epochs when validation loss is not decreasing during a coupe of epochs

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -12,14 +12,14 @@ class ModProgressBar(TQDMProgressBar):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.enable = True
+        self.enable()
 
     def disable(self):
-        self.enable = False
+        super().disable()
 
-    def get_metrics(self, trainer, model):
+    def get_metrics(self, trainer, pl_module):
         # don't show the version number
-        items = super().get_metrics(trainer, model)
+        items = super().get_metrics(trainer, pl_module)
         items.pop("v_num", None)
         return items
 
@@ -30,7 +30,7 @@ class ModProgressBar(TQDMProgressBar):
         # number of training steps
         total_batches = trainer.estimated_stepping_batches
         # Calculate max epochs
-        if trainer.max_epochs > 0:
+        if trainer.max_epochs is not None and trainer.max_epochs > 0:
             max_epochs = trainer.max_epochs
         else:
             max_epochs = 1 + (total_batches - 1) // trainer.num_training_batches
@@ -55,7 +55,7 @@ class ModProgressBar(TQDMProgressBar):
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         # Update the progress bar based on the total number of batches
-        n = batch_idx + trainer.current_epoch * trainer.num_training_batches + 1
+        n = int(batch_idx + trainer.current_epoch * trainer.num_training_batches + 1)
         if self._should_update(n, self.train_progress_bar.total):
             self.train_progress_bar.set_postfix(self.get_metrics(trainer, pl_module))
             if not (self.train_progress_bar.disable):

--- a/utils/system.py
+++ b/utils/system.py
@@ -20,7 +20,7 @@ def setup_system(cfg):
         torch.set_float32_matmul_precision("high")
 
 
-def save_train_config(log_dir, cfg):
+def save_train_config(log_dir: str, cfg):
 
     config_save_path = os.path.join(log_dir, "config.yaml")
     os.makedirs(os.path.dirname(config_save_path), exist_ok=True)


### PR DESCRIPTION
This pull request:

* Expands logging to log gradient magnitude and wallclock training step time
* Modifies the progress bars:
  * The training progress bar is based on the total number of training steps, not per-epoch
  * The validation progress bar is persistent in Jupyter notebooks
  * The useless 'v_num' tag is removed, freeing up space
* Adjusts type annotations for consistency
* Builds convenience nn.Modules under `simple_blocks.py` for all current nearly-linear modules and a few new ones (like learned global bias)
* Creates the generic multilayer block GMBlock, which is capable of replacing all current CLP (and other nn.Module) calls in the non-variational form of paradis